### PR TITLE
Document Arch Linux installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,3 +237,9 @@ menu root {
 
 Download the appropriate binary for your platform (windows is untested) from the release page, 
 or install via cargo: `cargo install --git https://github.com/knorrfg/dotree`.
+
+### Arch Linux
+
+- [dotree](https://aur.archlinux.org/packages/dotree)
+- [dotree-bin](https://aur.archlinux.org/packages/dotree-bin)
+- [dotree-git](https://aur.archlinux.org/packages/dotree-git)


### PR DESCRIPTION
I created a few packages for dotree in [the AUR](https://aur.archlinux.org/) and just added links to them in the installation section.